### PR TITLE
remove content_icon

### DIFF
--- a/plone/app/collection/profiles/default/types/Collection.xml
+++ b/plone/app/collection/profiles/default/types/Collection.xml
@@ -7,7 +7,6 @@
   <property name="title" i18n:translate="">Collection</property>
   <property name="description"
     i18n:translate="">Collection</property>
-  <property name="content_icon"></property>
   <property name="global_allow">True</property>
   <property name="filter_content_types">False</property>
   <property name="allowed_content_types" />


### PR DESCRIPTION
We don't need a content_icon as plone will load the default from sprite, 
&lt;property name="content_icon">&lt;/property> will generate a 404 in de add new menu dropdown
