### PR TITLE
Check for isPrincipiaFolderish and image types in getFoldersAndImages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
+- Check if item isPrincipiaFolderish instead of the harcoded portal_type
+  Folder when searching for images
+ [ichimdav]
+
 - Fix thumbnail_view so it works with any portal_atct image types not just
   with Image and News Items
   [ichimdav]

--- a/plone/app/collection/collection.py
+++ b/plone/app/collection/collection.py
@@ -166,9 +166,9 @@ class Collection(document.ATDocument, ObjectManager):
 
         for item in results:
             item_path = item.getPath()
-            if item.portal_type == 'Folder':
+            if item.isPrincipiaFolderish:
                 query = {
-                    'portal_type': 'Image',
+                    'portal_type': image_types,
                     'path': item_path,
                 }
                 _mapping['images'][item_path] = IContentListing(catalog(query))


### PR DESCRIPTION
With these changes, any folderish content type could be used to check for any image_type instead of the hardcoded Folder and Image.
This should be a natural choice since there was a changeset that added Image and News Items to the images since there was an error when trying to display News Items
https://github.com/ichim-david/plone.app.collection/commit/d93849ef534fd9d037e840c458a0d72a806f2e2c
