### PR TITLE
Remove existing FTI (FTI) from portal_types when installing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Changelog
 
 Fixes:
 
+- Remove existing type information object (FTI) from portal_types when
+  installing.  This might be a dexterity FTI, which would give an
+  error when installing: ValueError: undefined property
+  ``content_meta_type``.  [maurits]
+
 - Pull typesUseViewActionInListings value from portal_registry.
   [esteele]
 

--- a/plone/app/collection/profiles/default/types.xml
+++ b/plone/app/collection/profiles/default/types.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <object name="portal_types">
+   <!-- We remove the existing FTI since itcould be Dexterity-based and would
+        not be compatible in that case.  You get this error when installing:
+        ValueError: undefined property 'content_meta_type' -->
+  <object name="Collection" remove="True"/>
   <object name="Collection"
           meta_type="Factory-based Type Information with dynamic views" />
 </object>


### PR DESCRIPTION
This might be a dexterity FTI, which would give an error when installing:

```
ValueError: undefined property content_meta_type.
```

Products.ATContentTypes already does this for the other types.