### PR TITLE
Add uninstall profile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Added uninstall profile.  The Collection type is removed when you
+  uninstall this package.  [maurits]
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.1.7 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
 Incompatibilities:

--- a/plone/app/collection/configure.zcml
+++ b/plone/app/collection/configure.zcml
@@ -9,12 +9,20 @@
   <include package="plone.app.querystring" />
   <include package="plone.app.contentlisting" />
   <include package=".browser" />
-  
+
   <genericsetup:registerProfile
     name="default"
     title="plone.app.collection"
     directory="profiles/default"
     description="Archetypes-based collections"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
+
+  <genericsetup:registerProfile
+    name="uninstall"
+    title="plone.app.collection"
+    directory="profiles/uninstall"
+    description="Archetypes-based collections (uninstall)"
     provides="Products.GenericSetup.interfaces.EXTENSION"
     />
 

--- a/plone/app/collection/profiles/default/types.xml
+++ b/plone/app/collection/profiles/default/types.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <object name="portal_types">
-   <!-- We remove the existing FTI since itcould be Dexterity-based and would
+   <!-- We remove the existing FTI since it could be Dexterity-based and would
         not be compatible in that case.  You get this error when installing:
         ValueError: undefined property 'content_meta_type' -->
   <object name="Collection" remove="True"/>

--- a/plone/app/collection/profiles/uninstall/types.xml
+++ b/plone/app/collection/profiles/uninstall/types.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_types">
+  <object name="Collection" remove="True"/>
+</object>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.1.7.dev0'
+version = '1.2.0.dev0'
 
 setup(name='plone.app.collection',
       version=version,


### PR DESCRIPTION
Helps for the QI plip: https://github.com/plone/Products.CMFPlone/issues/1369

Before this gets merged, I propose we create a 1.1.x branch for Plone 5.0.
Technically it would be fine to include this uninstall profile in Plone 5.0, but since we are starting to take semantic versioning (http://semver.org) more seriously, we should let 5.0 use the stable branch.