### PR TITLE
Summary view crashes when collection has Discussion Items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Fix summary view for results with Discussion Items
+  [ichim-david]
+
 - Check with getattr if item isPrincipiaFolderish as Comment does
   not have this attribute which would render an AttributeError
   [ichim-david]

--- a/plone/app/collection/browser/templates/summary_view.pt
+++ b/plone/app/collection/browser/templates/summary_view.pt
@@ -18,12 +18,12 @@
         <div class="tileItem visualIEFloatFix"
              tal:define="obj item/getObject">
             <a href="#"
-                  tal:condition="obj/image|nothing"
+                  tal:define="scales obj/@@images|nothing"
+                  tal:condition="scales"
                   tal:attributes="href item/getURL">
                   <div class="tileImage">
                       <img src="" alt=""
-                           tal:define="scales obj/@@images;
-                                       scale python:scales.scale('image', 'thumb')"
+                           tal:define="scale python:scales.scale('image', 'thumb') if scales else None"
                            tal:replace="structure python:scale and scale.tag(css_class='tileImage') or None" />
                   </div>
             </a>


### PR DESCRIPTION
Although item/image gave a result
calling item/@@images gave an attribute error.

This commit checks directly for item/@@images since the scale is done through
this browserView so if that is not found then no image should be added such as
in the case of the Discussion Item