### PR TITLE
Remove installation of plone.app.widgets default profile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove installation of plone.app.widgets default profile.
+  In Plone 5.0/5.1 with plone.app.widgets >= 2.0, the profile is only a dummy profile for BBB.
+  In Plone 5.2 will be removed.
+  [jensens]
 
 
 1.2.6 (2018-02-04)

--- a/plone/app/collection/profiles/default/metadata.xml
+++ b/plone/app/collection/profiles/default/metadata.xml
@@ -3,6 +3,5 @@
   <version>1</version>
   <dependencies>
     <dependency>profile-plone.app.querystring:default</dependency>
-    <dependency>profile-plone.app.widgets:default</dependency>
   </dependencies>
 </metadata>


### PR DESCRIPTION
In Plone 5.0/5,. with plone.app.widgets >= 2.0, the profile is only a dummy profile for BBB.
In Plone 5.2 will be removed.